### PR TITLE
Improve package script

### DIFF
--- a/src/scripts/package.sh
+++ b/src/scripts/package.sh
@@ -1,1 +1,5 @@
-zip "$OUTPUT_FILE" "$INPUT_FILE"
+# shellcheck disable=SC2153
+input_parentdir="$(dirname "$INPUT_FILE")"
+input_file="$(basename "$INPUT_FILE")"
+output_realpath="$(realpath "$OUTPUT_FILE")"
+cd "$input_parentdir" && zip "$output_realpath" "$input_file"


### PR DESCRIPTION
Improves the package.sh script enabling it to zip binaries when the files are in nested folders in such a way that it works with aws lambda.
With this change the input file variable (`INPUT_FILE`) could be something like `path/to/unzipped/file`